### PR TITLE
Update list.lua

### DIFF
--- a/list.lua
+++ b/list.lua
@@ -2227,7 +2227,7 @@ t.case_table = {
 	level = "2",
 	faction = "Horde",
     category = "raid",
-    description = "Removes pug at the end of a 3 SR run for "toxicity" right as his reserved loot is being rolled on. Shown that player was not toxic, but only questioning their unusual loot rules.",
+    description = "Removes pug at the end of a 3 SR run for toxicity right as his reserved loot is being rolled on. Shown that player was not toxic, but only questioning their unusual loot rules.",
     url = "https://discord.com/channels/757975796249002118/1155268064858865805",  
     },
 	[269]= {


### PR DESCRIPTION
Fixing double quotes causing lua errors

1x Interface_Wrath\FrameXML\Bindings.xml:1 Scambuster-Faerlina/list.lua:1 Scambuster-Faerlina/list.lua:2230: '}' expected (to close '{' at line 2224) near 'toxicity'